### PR TITLE
UNITTESTS-FETCHER: unit tests for functions in module

### DIFF
--- a/promua_fetcher/order_fetcher.py
+++ b/promua_fetcher/order_fetcher.py
@@ -1,7 +1,7 @@
 import json
 import http.client
 import time
-from config import *
+from promua_fetcher.config import *
 import mysql.connector
 from mysql.connector import errorcode
 import argparse

--- a/unit_tests/test_order_fetcher.py
+++ b/unit_tests/test_order_fetcher.py
@@ -1,7 +1,8 @@
 import unittest
-# import mock
 from unittest import mock
 import sys
+from mock import patch
+import json
 from promua_fetcher.order_fetcher import init_parameters
 from promua_fetcher.order_fetcher import MySQLClient
 from promua_fetcher.order_fetcher import PromuaAPIClient
@@ -33,3 +34,18 @@ class TestMySQLClient(unittest.TestCase):
         mockconnect.assert_called()
 
 
+class TestPromuaAPIClient(unittest.TestCase):
+
+    @patch('promua_fetcher.order_fetcher.PromuaAPIClient.make_request')
+    def test_get_order_list(self, make_request_mock):
+        make_request_mock.return_value = json.loads('{"groups":[{"id":0,"name":"string","description": "string"}]}')
+        prom_client = PromuaAPIClient("TOKEN", "HOST")
+        self.assertIsInstance(prom_client.get_order_list(), dict)
+
+    @patch('promua_fetcher.order_fetcher.PromuaAPIClient.make_request')
+    def test_get_order_id_status_name(self, make_request_mock):
+        make_request_mock.return_value = json.loads('{  "order":  {"id":0,"status_name":"test_string"} }')
+        prom_client = PromuaAPIClient("TOKEN", "HOST")
+        test_data = prom_client.get_order_id_status_name(5)
+        self.assertIsInstance(test_data, str)
+        self.assertEqual(test_data, "test_string")

--- a/unit_tests/test_order_fetcher.py
+++ b/unit_tests/test_order_fetcher.py
@@ -1,0 +1,23 @@
+import unittest
+import sys
+from promua_fetcher.order_fetcher import init_parameters
+from promua_fetcher.order_fetcher import MySQLClient
+from promua_fetcher.order_fetcher import PromuaAPIClient
+
+
+class TestArgParser(unittest.TestCase):
+    """Suite for testing command line arguments parser"""
+
+    def test_Version(self):
+        """Checking '--version' argument"""
+        sys.argv[1:] = ['--version']
+        with self.assertRaises(SystemExit, msg="'--version' parameter parsed in wrong way"):
+            init_parameters()
+
+    def test_Mode(self):
+        """Checking parsing URL parameter"""
+        sys.argv[1:] = ['fetch']
+        options = init_parameters()
+        self.assertEqual(options.source, 'fetch', "Failure to pass URL from command line")
+
+

--- a/unit_tests/test_order_fetcher.py
+++ b/unit_tests/test_order_fetcher.py
@@ -1,4 +1,6 @@
 import unittest
+# import mock
+from unittest import mock
 import sys
 from promua_fetcher.order_fetcher import init_parameters
 from promua_fetcher.order_fetcher import MySQLClient
@@ -19,5 +21,15 @@ class TestArgParser(unittest.TestCase):
         sys.argv[1:] = ['fetch']
         options = init_parameters()
         self.assertEqual(options.mode, 'fetch', "Failure to pass mode from command line")
+
+
+class TestMySQLClient(unittest.TestCase):
+
+    @mock.patch('mysql.connector.connect')
+    def test_connect_db(self, mockconnect):
+        client = MySQLClient("TEST_DB_HOST", "TEST_DB_PORT", "TEST_DB_NAME", "TEST_DB_USER", "TEST_DB_PASS")
+        connection = client.connect_db()
+        self.assertIsNotNone(connection)
+        mockconnect.assert_called()
 
 

--- a/unit_tests/test_order_fetcher.py
+++ b/unit_tests/test_order_fetcher.py
@@ -18,6 +18,6 @@ class TestArgParser(unittest.TestCase):
         """Checking parsing URL parameter"""
         sys.argv[1:] = ['fetch']
         options = init_parameters()
-        self.assertEqual(options.source, 'fetch', "Failure to pass URL from command line")
+        self.assertEqual(options.mode, 'fetch', "Failure to pass mode from command line")
 
 


### PR DESCRIPTION
Not covered by unit tests functions:
PromuaAPIClient.make_request
MySQLClient.disconnect_db
MySQLClient.insert_order
MySQLClient.get_unfiltered_orders
MySQLClient.update_order_status
Main reason: unable to mock, also some tests are out of unit testing scope (maybe functional?).